### PR TITLE
BUGFIX: Replace --privileged with the specific device.

### DIFF
--- a/docker_instructions.md
+++ b/docker_instructions.md
@@ -19,7 +19,7 @@
 
 Set up your stream on the [YouTube Live Dashboard](https://www.youtube.com/live_dashboard) and enter your stream id and IP address in the command below in place of xxxx-xxxx-xxxx-xxxx and <ip>.
 
-    docker run --privileged --name YouTubeLive -ti octoprint/youtubelive:latest http://<ip>:8080/?action=stream xxxx-xxxx-xxxx-xxxx null
+    docker run --device=/dev/vchiq --name YouTubeLive -ti octoprint/youtubelive:latest http://<ip>:8080/?action=stream xxxx-xxxx-xxxx-xxxx null
 
 Stream should go live and re-encode the OctoPrint stream to YouTube.  Once verified close ffmpeg and remove docker container.
 	

--- a/octoprint_youtubelive/__init__.py
+++ b/octoprint_youtubelive/__init__.py
@@ -94,7 +94,7 @@ class youtubelive(octoprint.plugin.StartupPlugin,
 			if len(filters) == 0:
 				filters.append("null")
 			try:
-				self.container = self.client.containers.run("octoprint/youtubelive:latest",command=[self._settings.global_get(["webcam","stream"]),self._settings.get(["stream_id"]),",".join(filters)],detach=True,privileged=True,name="YouTubeLive",auto_remove=True)
+				self.container = self.client.containers.run("octoprint/youtubelive:latest",command=[self._settings.global_get(["webcam","stream"]),self._settings.get(["stream_id"]),",".join(filters)],detach=True,privileged=False,devices=["/dev/vchiq"],name="YouTubeLive",auto_remove=True)
 				self._plugin_manager.send_plugin_message(self._identifier, dict(status=True,streaming=True))
 			except Exception, e:
 				self._plugin_manager.send_plugin_message(self._identifier, dict(error=str(e),status=True,streaming=False))


### PR DESCRIPTION
Using docker's privileged mode is a really bad security
practice as it grants the container full control over
the host. This resolves issue #48 