### PR TITLE
Escape PNotify notifications

### DIFF
--- a/octoprint_youtubelive/static/js/youtubelive.js
+++ b/octoprint_youtubelive/static/js/youtubelive.js
@@ -74,6 +74,7 @@ $(function () {
 				new PNotify({
 							title: 'YouTube Live Error',
 							text: data.error,
+							text_escape: true,
 							type: 'error',
 							hide: false,
 							buttons: {


### PR DESCRIPTION
This plugin uses PNotify notifications to display Python exception messages in the frontend when they occur. We can probably assume they're safe, but since they don't need to be rendered as HTML, it's best to disable HTML parsing for these messages to ensure they can't execute JavaScript.